### PR TITLE
NoCache class requires parentheses for decorator, unlike Cache

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/perscache/cache.py
+++ b/perscache/cache.py
@@ -138,7 +138,7 @@ class NoCache:
     ```
     cache = NoCache() if os.environ["DEBUG"] else Cache()
 
-    @cache.cache
+    @cache
     def function():
         ...
     ```
@@ -147,24 +147,24 @@ class NoCache:
     def __repr__(self) -> str:
         return "<NoCache>"
 
-    @staticmethod
-    def __call__(*decorator_args, **decorator_kwargs):
+    def __call__(self, *decorator_args, **decorator_kwargs):
         """Will call the decorated function every time and
         return its result without any caching.
         """
+        if decorator_args and callable(decorator_args[0]):
+            return self._decorator(decorator_args[0])
+        return self._decorator
 
-        def _decorator(fn):
-            @functools.wraps(fn)
-            def _non_async_wrapper(*args, **kwargs):
-                return fn(*args, **kwargs)
+    def _decorator(self, fn):
+        @functools.wraps(fn)
+        def _non_async_wrapper(*args, **kwargs):
+            return fn(*args, **kwargs)
 
-            @functools.wraps(fn)
-            async def _async_wrapper(*args, **kwargs):
-                return await fn(*args, **kwargs)
+        @functools.wraps(fn)
+        async def _async_wrapper(*args, **kwargs):
+            return await fn(*args, **kwargs)
 
-            return _async_wrapper if is_async(fn) else _non_async_wrapper
-
-        return _decorator
+        return _async_wrapper if is_async(fn) else _non_async_wrapper
 
     cache = __call__  # Alias for backwards compatibility.
 

--- a/tests/test_nocache.py
+++ b/tests/test_nocache.py
@@ -1,13 +1,19 @@
 from perscache import NoCache
+import asyncio
 
 def test_no_cache_with_parentheses():
-
+    counter = 0
     cache = NoCache()
     @cache()
     def dummy_func():
+        nonlocal counter
+        counter += 1
         return 'NoCache with parentheses'
 
     assert dummy_func() == 'NoCache with parentheses'
+    assert dummy_func() == 'NoCache with parentheses'
+    assert counter == 2
+
 
 def test_no_cache_without_parentheses():
     cache = NoCache()
@@ -17,3 +23,23 @@ def test_no_cache_without_parentheses():
         return 'NoCache without parentheses'
 
     assert dummy_func() == 'NoCache without parentheses'
+
+
+async def test_no_cache_with_parentheses_async():
+    cache = NoCache()
+
+    @cache()
+    async def dummy_func():
+        return 'NoCache with parentheses async'
+
+    assert await dummy_func() == 'NoCache with parentheses async'
+
+
+async def test_no_cache_without_parentheses_async():
+    cache = NoCache()
+
+    @cache
+    async def dummy_func():
+        return 'NoCache without parentheses async'
+
+    assert await dummy_func() == 'NoCache without parentheses async'

--- a/tests/test_nocache.py
+++ b/tests/test_nocache.py
@@ -1,0 +1,19 @@
+from perscache import NoCache
+
+def test_no_cache_with_parentheses():
+
+    cache = NoCache()
+    @cache()
+    def dummy_func():
+        return 'NoCache with parentheses'
+
+    assert dummy_func() == 'NoCache with parentheses'
+
+def test_no_cache_without_parentheses():
+    cache = NoCache()
+
+    @cache
+    def dummy_func():
+        return 'NoCache without parentheses'
+
+    assert dummy_func() == 'NoCache without parentheses'


### PR DESCRIPTION
Fixes #19

## Summary by Sourcery

Fix the NoCache class to support usage as a decorator with or without parentheses and add corresponding tests to ensure correct functionality.

Bug Fixes:
- Fix the NoCache class to allow usage as a decorator both with and without parentheses.

Tests:
- Add tests for NoCache to verify its functionality with and without parentheses when used as a decorator.